### PR TITLE
Update colors to Trello-inspired palette

### DIFF
--- a/html/components/action-button/action-button.css
+++ b/html/components/action-button/action-button.css
@@ -8,7 +8,7 @@
   border-radius: 100%;
   background-color: var(--action-button-background-color);
   box-shadow: 4px 4px 8px rgba(0, 0, 0, 0.4);
-  color: inherit;
+  color: var(--action-button-color);
 }
 .action-button::after {
   content: "+";
@@ -36,6 +36,7 @@
     border-radius: 10px;
     margin: 25px;
     background-color: var(--action-button-background-color);
+    color: var(--action-button-color);
   }
   .static-action-button:hover {
     background-color: #ccc;

--- a/html/components/footer/footer.css
+++ b/html/components/footer/footer.css
@@ -3,4 +3,5 @@ footer {
   justify-content: center;
   align-items: center;
   background-color: var(--footer-background-color);
+  color: #fff;
 }

--- a/html/components/nav/nav.css
+++ b/html/components/nav/nav.css
@@ -3,12 +3,15 @@
   justify-content: space-between;
   align-items: center;
   background-color: var(--nav-background-color);
+  color: #fff;
 }
 .navbar-logo {
   padding-left: 20px;
+  color: inherit;
 }
 .navbar-links a {
   text-decoration: none;
   font-size: 20px;
   padding-right: 20px;
+  color: inherit;
 }

--- a/html/components/note/note.css
+++ b/html/components/note/note.css
@@ -1,5 +1,5 @@
 .card {
-  background-color: #fff;
+  background-color: var(--card-background-color);
   width: clamp(288px, 80vw, 388px);
   height: clamp(288px, 80vh, 388px);
   overflow: hidden;

--- a/html/components/note/note.css
+++ b/html/components/note/note.css
@@ -1,5 +1,5 @@
 .card {
-  background-color: #fdfd96;
+  background-color: #fff;
   width: clamp(288px, 80vw, 388px);
   height: clamp(288px, 80vh, 388px);
   overflow: hidden;

--- a/html/components/todo/todo.css
+++ b/html/components/todo/todo.css
@@ -3,7 +3,7 @@
   margin-bottom: 1rem;
   width: clamp(288px, 80vw, 388px);
   height: clamp(288px, 80vh, 428px);
-  background-color: #fff;
+  background-color: var(--card-background-color);
   /*font-family: "Permanent Marker", cursive;*/
   font-family: "Patrick Hand", cursive;
   font-size: clamp(22px, 2.5vw, 24px);

--- a/html/components/todo/todo.css
+++ b/html/components/todo/todo.css
@@ -3,7 +3,7 @@
   margin-bottom: 1rem;
   width: clamp(288px, 80vw, 388px);
   height: clamp(288px, 80vh, 428px);
-  background-color: #fdfd96;
+  background-color: #fff;
   /*font-family: "Permanent Marker", cursive;*/
   font-family: "Patrick Hand", cursive;
   font-size: clamp(22px, 2.5vw, 24px);

--- a/html/components/toggle-button/toggle-button.css
+++ b/html/components/toggle-button/toggle-button.css
@@ -4,7 +4,7 @@
   left: 1rem;
   z-index: 1100;
   background-color: var(--toggle-aside-background-color);
-  color: black;
+  color: #fff;
   border: none;
   padding: 0.75rem;
   border-radius: 50%;

--- a/variables.css
+++ b/variables.css
@@ -1,9 +1,9 @@
 :root {
-  --aside-background-color: #f0f0f0;
-  --footer-background-color: #fff;
-  --nav-background-color: #ccc;
-  --action-button-background-color: #7155dd;
-  --toggle-aside-background-color: #7155dd;
+  --aside-background-color: #f4f5f7;
+  --footer-background-color: #026aa7;
+  --nav-background-color: #026aa7;
+  --action-button-background-color: #5aac44;
+  --toggle-aside-background-color: #5aac44;
   --action-button-color: #fff;
-  --main-background-color: #fafafa;
+  --main-background-color: #f4f5f7;
 }

--- a/variables.css
+++ b/variables.css
@@ -5,5 +5,6 @@
   --action-button-background-color: #5aac44;
   --toggle-aside-background-color: #5aac44;
   --action-button-color: #fff;
+  --card-background-color: #fff;
   --main-background-color: #f4f5f7;
 }


### PR DESCRIPTION
## Summary
- switch global color variables to Trello-like blue and gray
- use these variables in navigation and footer with white text
- style buttons with new brand colors
- turn todo and note card backgrounds white for a cleaner look

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684f26922864832bac889ed22d973879