### PR TITLE
Add dark/light mode

### DIFF
--- a/html/components/body/body.css
+++ b/html/components/body/body.css
@@ -3,6 +3,7 @@ body {
   min-height: 100vh;
   /*font-family: Arial, Helvetica, sans-serif;*/
   font-family: "Poppins", sans-serif;
+  color: var(--text-color);
   grid-template-rows: 70px 1fr 70px;
   grid-template-columns: 1fr;
   grid-template-areas:

--- a/html/components/footer/footer.css
+++ b/html/components/footer/footer.css
@@ -3,5 +3,5 @@ footer {
   justify-content: center;
   align-items: center;
   background-color: var(--footer-background-color);
-  color: #fff;
+  color: var(--text-color);
 }

--- a/html/components/modal/modal.css
+++ b/html/components/modal/modal.css
@@ -1,0 +1,14 @@
+.modal-content {
+  background-color: var(--modal-background-color);
+  color: var(--text-color);
+}
+
+.modal-header,
+.modal-footer {
+  background-color: var(--modal-background-color);
+  border-color: var(--text-color);
+}
+
+.dark-theme .btn-close {
+  filter: invert(1);
+}

--- a/html/components/nav/nav.css
+++ b/html/components/nav/nav.css
@@ -3,7 +3,7 @@
   justify-content: space-between;
   align-items: center;
   background-color: var(--nav-background-color);
-  color: #fff;
+  color: var(--text-color);
 }
 .navbar-logo {
   padding-left: 20px;

--- a/html/components/nav/nav.css
+++ b/html/components/nav/nav.css
@@ -9,6 +9,11 @@
   padding-left: 20px;
   color: inherit;
 }
+
+.navbar-links {
+  display: flex;
+  align-items: center;
+}
 .github-logo {
   height: 32px;
 }

--- a/html/components/nav/nav.css
+++ b/html/components/nav/nav.css
@@ -9,6 +9,13 @@
   padding-left: 20px;
   color: inherit;
 }
+.github-logo {
+  height: 32px;
+}
+
+.dark-theme .github-logo {
+  filter: invert(1);
+}
 .navbar-links a {
   text-decoration: none;
   font-size: 20px;

--- a/html/components/theme-button/theme-buttons.css
+++ b/html/components/theme-button/theme-buttons.css
@@ -12,3 +12,19 @@
   height: 1.5rem;
   fill: currentColor;
 }
+
+.moon-icon {
+  display: block;
+}
+
+.sun-icon {
+  display: none;
+}
+
+.dark-theme .sun-icon {
+  display: block;
+}
+
+.dark-theme .moon-icon {
+  display: none;
+}

--- a/html/components/theme-button/theme-buttons.css
+++ b/html/components/theme-button/theme-buttons.css
@@ -6,3 +6,9 @@
   cursor: pointer;
   margin-right: 1rem;
 }
+
+.theme-toggle-btn svg {
+  width: 1.5rem;
+  height: 1.5rem;
+  fill: currentColor;
+}

--- a/html/components/theme-button/theme-buttons.css
+++ b/html/components/theme-button/theme-buttons.css
@@ -5,12 +5,15 @@
   font-size: 1.5rem;
   cursor: pointer;
   margin-right: 1rem;
+  display: flex;
+  align-items: center;
 }
 
 .theme-toggle-btn svg {
-  width: 1.5rem;
-  height: 1.5rem;
+  width: 2rem;
+  height: 2rem;
   fill: currentColor;
+  display: block;
 }
 
 .moon-icon {

--- a/html/components/theme-button/theme-buttons.css
+++ b/html/components/theme-button/theme-buttons.css
@@ -1,13 +1,8 @@
 .theme-toggle-btn {
-  position: fixed;
-  top: 1rem;
-  right: 4rem;
-  z-index: 2000;
-  padding: 0.5rem 0.75rem;
-  font-size: 1.2rem;
   background-color: transparent;
-  color: var(--text-color);
-  border: 1px solid var(--text-color);
-  border-radius: 6px;
+  color: inherit;
+  border: none;
+  font-size: 1.5rem;
   cursor: pointer;
+  margin-right: 1rem;
 }

--- a/html/components/theme-button/theme-buttons.css
+++ b/html/components/theme-button/theme-buttons.css
@@ -13,7 +13,6 @@
   width: 2rem;
   height: 2rem;
   fill: currentColor;
-  display: block;
 }
 
 .moon-icon {

--- a/index.html
+++ b/index.html
@@ -47,8 +47,8 @@
       <h1 class="navbar-logo">Manage your tasks</h1>
       <div class="navbar-links">
         <button id="theme-toggle" class="theme-toggle-btn" aria-label="Toggle theme">
-          <svg class="moon-icon" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
-            <path d="M8 15A7 7 0 108 1v14z" />
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon" class="moon-icon" height="20">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M21.752 15.002A9.72 9.72 0 0 1 18 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 0 0 3 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 0 0 9.002-5.998Z"></path>
           </svg>
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" class="sun-icon">
             <path stroke-linecap="round" stroke-linejoin="round" d="M12 3v2.25m6.364.386-1.591 1.591M21 12h-2.25m-.386 6.364-1.591-1.591M12 18.75V21m-4.773-4.227-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0Z"/>

--- a/index.html
+++ b/index.html
@@ -51,7 +51,7 @@
           <img
             src="./html/components/img/github.png"
             alt="Github"
-            style="height: 32px"
+            class="github-logo"
           />
         </a>
       </div>

--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@
           <svg class="moon-icon" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
             <path d="M8 15A7 7 0 108 1v14z" />
           </svg>
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" class="sun-icon" height="20">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" class="sun-icon">
             <path stroke-linecap="round" stroke-linejoin="round" d="M12 3v2.25m6.364.386-1.591 1.591M21 12h-2.25m-.386 6.364-1.591-1.591M12 18.75V21m-4.773-4.227-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0Z"/>
           </svg>
         </button>

--- a/index.html
+++ b/index.html
@@ -47,8 +47,11 @@
       <h1 class="navbar-logo">Manage your tasks</h1>
       <div class="navbar-links">
         <button id="theme-toggle" class="theme-toggle-btn" aria-label="Toggle theme">
-          <svg class="theme-icon" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+          <svg class="moon-icon" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
             <path d="M8 15A7 7 0 108 1v14z" />
+          </svg>
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" class="sun-icon" height="20">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M12 3v2.25m6.364.386-1.591 1.591M21 12h-2.25m-.386 6.364-1.591-1.591M12 18.75V21m-4.773-4.227-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0Z"/>
           </svg>
         </button>
         <a href="https://github.com/JustinWaiz/js-todo-app" target="_blank">

--- a/index.html
+++ b/index.html
@@ -46,6 +46,7 @@
     <nav class="navbar">
       <h1 class="navbar-logo">Manage your tasks</h1>
       <div class="navbar-links">
+        <button id="theme-toggle" class="theme-toggle-btn">🌓</button>
         <a href="https://github.com/JustinWaiz/js-todo-app" target="_blank">
           <img
             src="./html/components/img/github.png"

--- a/index.html
+++ b/index.html
@@ -46,7 +46,11 @@
     <nav class="navbar">
       <h1 class="navbar-logo">Manage your tasks</h1>
       <div class="navbar-links">
-        <button id="theme-toggle" class="theme-toggle-btn">🌓</button>
+        <button id="theme-toggle" class="theme-toggle-btn" aria-label="Toggle theme">
+          <svg class="theme-icon" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+            <path d="M8 15A7 7 0 108 1v14z" />
+          </svg>
+        </button>
         <a href="https://github.com/JustinWaiz/js-todo-app" target="_blank">
           <img
             src="./html/components/img/github.png"

--- a/js/index.js
+++ b/js/index.js
@@ -343,4 +343,17 @@ class TodoRenderService {
   document.getElementById("toggle-aside").addEventListener("click", () => {
     document.body.classList.toggle("aside-collapsed");
   });
+
+  const themeToggleBtn = document.getElementById("theme-toggle");
+  const savedTheme = localStorage.getItem("theme");
+  if (savedTheme === "dark") {
+    document.body.classList.add("dark-theme");
+  }
+  themeToggleBtn.addEventListener("click", () => {
+    document.body.classList.toggle("dark-theme");
+    const theme = document.body.classList.contains("dark-theme")
+      ? "dark"
+      : "light";
+    localStorage.setItem("theme", theme);
+  });
 })();

--- a/styles.css
+++ b/styles.css
@@ -8,6 +8,7 @@
 @import url("./html/components/aside/aside.css");
 @import url("./html/components/body/body.css");
 @import url("./html/components/todo/todo.css");
+@import url("./html/components/modal/modal.css");
 
 * {
   margin: 0;

--- a/styles.css
+++ b/styles.css
@@ -2,6 +2,7 @@
 @import url("./html/components/action-button/action-button.css");
 @import url("./html/components/filter-buttons/filter-buttons.css");
 @import url("./html/components/toggle-button/toggle-button.css");
+@import url("./html/components/theme-button/theme-buttons.css");
 @import url("./html/components/footer/footer.css");
 @import url("./html/components/nav/nav.css");
 @import url("./html/components/aside/aside.css");

--- a/variables.css
+++ b/variables.css
@@ -17,7 +17,7 @@
   --action-button-background-color: #3d8b3d;
   --toggle-aside-background-color: #3d8b3d;
   --action-button-color: #fff;
-  --card-background-color: #3c3c3c;
+  --card-background-color: #444;
   --main-background-color: #222;
   --text-color: #fff;
 }

--- a/variables.css
+++ b/variables.css
@@ -7,6 +7,7 @@
   --action-button-color: #fff;
   --card-background-color: #fdfd96;
   --main-background-color: #f4f5f7;
+  --modal-background-color: #fff;
   --text-color: #000;
 }
 
@@ -19,5 +20,6 @@
   --action-button-color: #fff;
   --card-background-color: #444;
   --main-background-color: #222;
+  --modal-background-color: #333;
   --text-color: #fff;
 }

--- a/variables.css
+++ b/variables.css
@@ -7,4 +7,17 @@
   --action-button-color: #fff;
   --card-background-color: #fdfd96;
   --main-background-color: #f4f5f7;
+  --text-color: #000;
+}
+
+.dark-theme {
+  --aside-background-color: #2c2c2c;
+  --footer-background-color: #1f1f1f;
+  --nav-background-color: #1f1f1f;
+  --action-button-background-color: #3d8b3d;
+  --toggle-aside-background-color: #3d8b3d;
+  --action-button-color: #fff;
+  --card-background-color: #3c3c3c;
+  --main-background-color: #222;
+  --text-color: #fff;
 }


### PR DESCRIPTION
## Summary
- create dark theme variables and text color
- add dark-theme class toggle logic
- import theme button style and add toggle button
- support persistent theme setting
- move theme button inside navbar

## Testing
- `git status -s`


------
https://chatgpt.com/codex/tasks/task_e_6851628ac738832bac8a2190b13e608f